### PR TITLE
Create a warning instead of an error for TransformExceptions

### DIFF
--- a/hector_trajectory_server/src/hector_trajectory_server.cpp
+++ b/hector_trajectory_server/src/hector_trajectory_server.cpp
@@ -119,7 +119,7 @@ public:
       addCurrentTfPoseToTrajectory();
     }catch(tf::TransformException e)
     {
-      ROS_ERROR("Trajectory Server: Transform from %s to %s failed: %s \n", p_target_frame_name_.c_str(), pose_source_.header.frame_id.c_str(), e.what() );
+      ROS_WARN("Trajectory Server: Transform from %s to %s failed: %s \n", p_target_frame_name_.c_str(), pose_source_.header.frame_id.c_str(), e.what() );
     }
   }
 


### PR DESCRIPTION
Hi, this is Andi. I suggest to create a warning instead of an error in the trajectory server whenever a tf exception occurs. For me, the exception is always thrown once or twice at node startup and the error message is confusing as it seems like there is a serious runtime problem.
