### PR TITLE
hector_slam tutorials: -Add arguments to launch files for specifying geotiff file path

### DIFF
--- a/hector_geotiff/launch/geotiff_mapper.launch
+++ b/hector_geotiff/launch/geotiff_mapper.launch
@@ -4,6 +4,8 @@
    <arg name="trajectory_source_frame_name" default="/base_link"/>
    <arg name="trajectory_update_rate" default="4"/>
    <arg name="trajectory_publish_rate" default="0.25"/>
+   <arg name="map_file_path" default="$(find hector_geotiff)/maps"/>
+   <arg name="map_file_base_name" default="hector_slam_map"/>
   
   <node pkg="hector_trajectory_server" type="hector_trajectory_server" name="hector_trajectory_server" output="screen">
     <param name="target_frame_name" type="string" value="/map" />
@@ -12,11 +14,10 @@
     <param name="trajectory_publish_rate" type="double" value="$(arg trajectory_publish_rate)" />
   </node>
 
-
   <node pkg="hector_geotiff" type="geotiff_node" name="hector_geotiff_node" output="screen" launch-prefix="nice -n 15">
     <remap from="map" to="/dynamic_map" />
-    <param name="map_file_path" type="string" value="$(find hector_geotiff)/maps" />
-    <param name="map_file_base_name" type="string" value="hector_slam_map" />
+    <param name="map_file_path" type="string" value="$(arg map_file_path)" />
+    <param name="map_file_base_name" type="string" value="$(arg map_file_base_name)" />
     <param name="geotiff_save_period" type="double" value="0" />
     <param name="draw_background_checkerboard" type="bool" value="true" />
     <param name="draw_free_space_grid" type="bool" value="true" />

--- a/hector_slam_launch/launch/tutorial.launch
+++ b/hector_slam_launch/launch/tutorial.launch
@@ -1,6 +1,8 @@
 <?xml version="1.0"?>
 
 <launch>
+  
+  <arg name="geotiff_map_file_path" default="$(find hector_geotiff)/maps"/>
 
   <param name="/use_sim_time" value="true"/>
 
@@ -10,7 +12,8 @@
   <include file="$(find hector_mapping)/launch/mapping_default.launch"/>
  
   <include file="$(find hector_geotiff)/launch/geotiff_mapper.launch">
-    <arg name="trajectory_source_frame_name" value="scanmatcher_frame"/> 
+    <arg name="trajectory_source_frame_name" value="scanmatcher_frame"/>
+    <arg name="map_file_path" value="$(arg geotiff_map_file_path)"/> 
   </include>
 
 </launch>


### PR DESCRIPTION
Saving geotiff files to the default folder (the "maps" subfolder of the hector_geotiff package) is not possible when hector_slam is installed from .debs so far. This pull request adds arguments to launch files so the geotiff save path can be set from the tutorial launch command line like so:

<pre>
roslaunch hector_slam_launch tutorial.launch geotiff_map_file_path:=$HOME
</pre>


Will update http://wiki.ros.org/hector_slam/Tutorials/MappingUsingLoggedData after this has been pushed through to .debs.
