### PR TITLE
hector_trajectory_server: -Wait for tf become available to suppress warning spam on startup

### DIFF
--- a/hector_trajectory_server/src/hector_trajectory_server.cpp
+++ b/hector_trajectory_server/src/hector_trajectory_server.cpp
@@ -100,7 +100,7 @@ public:
       ros::WallTime now = ros::WallTime::now();
 
       if ((now-start).toSec() > 20.0 && !transform_successful){
-        ROS_WARN("No transform between frames %s and %s available after %f seconds of waiting.", p_target_frame_name_.c_str(), p_source_frame_name_.c_str(), (now-start).toSec());
+        ROS_WARN_ONCE("No transform between frames %s and %s available after %f seconds of waiting. This warning only prints once.", p_target_frame_name_.c_str(), p_source_frame_name_.c_str(), (now-start).toSec());
       }
     }
 


### PR DESCRIPTION
Sometimes ([1](http://answers.ros.org/question/40076/hector_slam-tutorial-errors/),[2](http://answers.ros.org/question/129891/mapping-trajectory-error/), see also #5) people get confused by hector_trajectory_server spitting out warnings (or errors in earlier versions) because tf data is not available during startup. This pull request adds a blocking wait for the required tf transform at the start, so a warning is not shown by default (only when more than 20s elapsed without tf data becoming available).
