### PR TITLE
Include _plugins package in run dependency

### DIFF
--- a/hector_geotiff/package.xml
+++ b/hector_geotiff/package.xml
@@ -46,6 +46,7 @@
   <build_depend>roscpp</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>libqt4-dev</build_depend>
+  <run_depend>hector_geotiff_plugins</run_depend>
   <run_depend>hector_map_tools</run_depend>
   <run_depend>hector_nav_msgs</run_depend>
   <run_depend>nav_msgs</run_depend>


### PR DESCRIPTION
Used to run https://github.com/tu-darmstadt-ros-pkg/hector_slam/blob/catkin/hector_geotiff/launch/geotiff_mapper.launch. Otherwise, trying to install from debs and running this launch file will fail.
