### PR TITLE
Load static map

### DIFF
--- a/hector_mapping/include/hector_slam_lib/map/GridMapLogOdds.h
+++ b/hector_mapping/include/hector_slam_lib/map/GridMapLogOdds.h
@@ -194,6 +194,19 @@ public:
     logOddsOccupied = probToLogOdds(factor);
   }
 
+  /**
+   * mark occupied cells as very occupied, and free cells very free
+   * @param cell The cell.
+   */
+  void stablize(LogOddsCell& cell) const
+  {
+    if (cell.isOccupied()) {
+      cell.logOddsVal = 50.0f;
+    } else if (cell.isFree()) {
+      cell.logOddsVal = -50.0f;
+    }
+  }
+
 protected:
 
   float probToLogOdds(float prob)

--- a/hector_mapping/include/hector_slam_lib/map/OccGridMapBase.h
+++ b/hector_mapping/include/hector_slam_lib/map/OccGridMapBase.h
@@ -96,6 +96,14 @@ public:
     return (this->getCell(index).isFree());
   }
 
+  void stablize()
+  {
+    int size = this->getSizeX() * this->getSizeY();
+    for (int i = 0; i < size; ++i) {
+      concreteGridFunctions.stablize(this->getCell(i));
+    }
+  }
+
   float getObstacleThreshold() const
   {
     ConcreteCellType temp;

--- a/hector_mapping/include/hector_slam_lib/map/OccGridMapBase.h
+++ b/hector_mapping/include/hector_slam_lib/map/OccGridMapBase.h
@@ -71,6 +71,21 @@ public:
     concreteGridFunctions.updateUnsetFree(this->getCell(index));
   }
 
+  void updateSetOccupied(int xMap, int yMap)
+  {
+    concreteGridFunctions.updateSetOccupied(this->getCell(xMap, yMap));
+  }
+
+  void updateSetFree(int xMap, int yMap)
+  {
+    concreteGridFunctions.updateSetFree(this->getCell(xMap, yMap));
+  }
+
+  void updateUnsetFree(int xMap, int yMap)
+  {
+    concreteGridFunctions.updateUnsetFree(this->getCell(xMap, yMap));
+  }
+
   float getGridProbabilityMap(int index) const
   {
     return concreteGridFunctions.getGridProbability(this->getCell(index));

--- a/hector_mapping/launch/mapping_default.launch
+++ b/hector_mapping/launch/mapping_default.launch
@@ -8,8 +8,11 @@
   <arg name="scan_subscriber_queue_size" default="5"/>
   <arg name="scan_topic" default="scan"/>
   <arg name="map_size" default="2048"/>
+  <arg name="use_static_map" default="true"/>
   
   <node pkg="hector_mapping" type="hector_mapping" name="hector_mapping" output="screen">
+    <!-- Load static map -->
+    <param name="use_static_map" value="$(arg use_static_map)" />
     
     <!-- Frame names -->
     <param name="map_frame" value="map" />

--- a/hector_mapping/src/HectorMappingRos.h
+++ b/hector_mapping/src/HectorMappingRos.h
@@ -91,6 +91,7 @@ public:
   void staticMapCallback(const nav_msgs::OccupancyGrid& map);
   void initialPoseCallback(const geometry_msgs::PoseWithCovarianceStampedConstPtr& msg);
 
+  bool loadStaticMap();
   void setStaticMapData(const nav_msgs::OccupancyGrid& map);
 protected:
 
@@ -122,7 +123,8 @@ protected:
   tf::Transform map_to_odom_;
 
   boost::thread* map__publish_thread_;
-
+  boost::mutex slamProcPtr_mutex_;
+	  
   hectorslam::HectorSlamProcessor* slamProcessor;
   hectorslam::DataContainer laserScanContainer;
 

--- a/hector_mapping/src/HectorMappingRos.h
+++ b/hector_mapping/src/HectorMappingRos.h
@@ -58,6 +58,7 @@ class HectorDebugInfoProvider;
 class MapPublisherContainer
 {
 public:
+  int lastGetMapUpdateIndex_;
   ros::Publisher mapPublisher_;
   ros::Publisher mapMetadataPublisher_;
   nav_msgs::GetMap::Response map_;
@@ -95,8 +96,6 @@ protected:
 
   HectorDebugInfoProvider* debugInfoProvider;
   HectorDrawings* hectorDrawings;
-
-  int lastGetMapUpdateIndex;
 
   ros::NodeHandle node_;
 

--- a/hector_mapping/src/HectorMappingRos.h
+++ b/hector_mapping/src/HectorMappingRos.h
@@ -90,9 +90,7 @@ public:
   void staticMapCallback(const nav_msgs::OccupancyGrid& map);
   void initialPoseCallback(const geometry_msgs::PoseWithCovarianceStampedConstPtr& msg);
 
-  /*
   void setStaticMapData(const nav_msgs::OccupancyGrid& map);
-  */
 protected:
 
   HectorDebugInfoProvider* debugInfoProvider;
@@ -183,6 +181,7 @@ protected:
   bool p_map_with_known_poses_;
   bool p_timing_output_;
 
+  bool p_use_static_map_;
 
   float p_sqr_laser_min_dist_;
   float p_sqr_laser_max_dist_;

--- a/hector_mapping/src/HectorMappingRos.h
+++ b/hector_mapping/src/HectorMappingRos.h
@@ -123,7 +123,7 @@ protected:
   tf::Transform map_to_odom_;
 
   boost::thread* map__publish_thread_;
-  boost::mutex slamProcPtr_mutex_;
+  boost::shared_mutex slamProcPtr_mutex_;
 	  
   hectorslam::HectorSlamProcessor* slamProcessor;
   hectorslam::DataContainer laserScanContainer;


### PR DESCRIPTION
In these commits I merely completed the method HectorMappingRos::setStaticMapData and use it to load map(s) from the service /static_map at startup and after receiving a "reload" command.

I have the needs to run a device in a same environment again and again with a same world coordinate system. Make hector_mapping load a static map (perhaps with an inaccurate initial pose) will give it a proper beginning. 

I use the ros node map_server#map_saver to save hector_mapping data into map files, and map_server#map_server to offer the /static_map service. If so, map_server's /map and /map_metadata topics should be remapped to some other names to avoid conflict. to be exactly, you need something like this in the launch file:
  <node name="static_map" pkg="map_server" type="map_server" args="$(find hector_mapping)/map/map.yaml" output="screen">
    <remap from="map" to="static_map"/>
    <remap from="map_metadata" to="static_map_metadata"/>
  </node>

---- updated on 2017/12/15 ----
It is hard to make hector_mapping use the given initial pose to start estimate right after loading a static map. So in the latest commit 0866395, I modified the command format to make two things done in one command.

