### PR TITLE
populate child_frame_id in odometry msg

### DIFF
--- a/hector_mapping/src/HectorMappingRos.cpp
+++ b/hector_mapping/src/HectorMappingRos.cpp
@@ -326,6 +326,7 @@ void HectorMappingRos::scanCallback(const sensor_msgs::LaserScan& scan)
     tmp.pose = poseInfoContainer_.getPoseWithCovarianceStamped().pose;
 
     tmp.header = poseInfoContainer_.getPoseWithCovarianceStamped().header;
+    tmp.child_frame_id = p_base_frame_;
     odometryPublisher_.publish(tmp);
   }
 


### PR DESCRIPTION
This is a simple pull request to add the "child_frame_id" in the hector mapping's odometry msg (it was coming out as blank).