### PR TITLE
Remove unnecessary boost signals find_package

### DIFF
--- a/hector_mapping/CMakeLists.txt
+++ b/hector_mapping/CMakeLists.txt
@@ -7,7 +7,7 @@ project(hector_mapping)
 find_package(catkin REQUIRED COMPONENTS roscpp nav_msgs visualization_msgs tf message_filters laser_geometry tf_conversions message_generation)
 
 ## System dependencies are found with CMake's conventions
-find_package(Boost REQUIRED COMPONENTS thread signals)
+find_package(Boost REQUIRED COMPONENTS thread)
 include_directories(${Boost_INCLUDE_DIRS})
 
 # Find Eigen3 (from http://wiki.ros.org/jade/Migration)


### PR DESCRIPTION
With Boost >1.69 hector_mapping won't build. Furthermore, hector_mapping doesn't use signals anywhere.

I propose this change because hector_mapping [is not building on Gentoo](https://github.com/ros/ros-overlay/issues/971) (and maybe Arch) cause of this.

Other packages had the same issue and were patched: https://github.com/ros-planning/navigation/pull/945

It would be very nice if this would follow with a re-release also. 

I also take this opportunity to say thanks for such an amazing package!