### PR TITLE
Add pause and reset services to hector_mapping

### DIFF
--- a/hector_mapping/CMakeLists.txt
+++ b/hector_mapping/CMakeLists.txt
@@ -1,7 +1,16 @@
 cmake_minimum_required(VERSION 3.0.2)
 project(hector_mapping)
 
-find_package(catkin REQUIRED COMPONENTS roscpp nav_msgs visualization_msgs tf message_filters laser_geometry tf_conversions message_generation)
+find_package(catkin REQUIRED COMPONENTS 
+  roscpp
+  nav_msgs
+  visualization_msgs
+  tf
+  message_filters
+  laser_geometry
+  tf_conversions
+  message_generation
+  std_srvs)
 
 find_package(Boost REQUIRED COMPONENTS thread)
 

--- a/hector_mapping/src/HectorMappingRos.cpp
+++ b/hector_mapping/src/HectorMappingRos.cpp
@@ -394,13 +394,13 @@ bool HectorMappingRos::pauseMapCallback(std_srvs::SetBool::Request  &req,
 {
   if (req.data && !pause_scan_processing_)
   {
-    res.message = "HectorSM Mapping paused";
-    ROS_INFO("%s", res.message.c_str());
+    res.message = "Mapping paused";
+    ROS_INFO("HectorSM %s", res.message.c_str());
   }
   else if (!req.data && pause_scan_processing_)
   {
-    res.message = "HectorSM Mapping no longer paused";
-    ROS_INFO("%s", res.message.c_str());
+    res.message = "Mapping no longer paused";
+    ROS_INFO("HectorSM %s", res.message.c_str());
   }
   pause_scan_processing_ = req.data;
   res.success = true;

--- a/hector_mapping/src/HectorMappingRos.cpp
+++ b/hector_mapping/src/HectorMappingRos.cpp
@@ -394,13 +394,11 @@ bool HectorMappingRos::pauseMapCallback(std_srvs::SetBool::Request  &req,
 {
   if (req.data && !pause_scan_processing_)
   {
-    res.message = "Mapping paused";
-    ROS_INFO("HectorSM %s", res.message.c_str());
+    ROS_INFO("HectorSM Mapping paused");
   }
   else if (!req.data && pause_scan_processing_)
   {
-    res.message = "Mapping no longer paused";
-    ROS_INFO("HectorSM %s", res.message.c_str());
+    ROS_INFO("HectorSM Mapping no longer paused");
   }
   pause_scan_processing_ = req.data;
   res.success = true;

--- a/hector_mapping/src/HectorMappingRos.cpp
+++ b/hector_mapping/src/HectorMappingRos.cpp
@@ -407,7 +407,6 @@ bool HectorMappingRos::pauseMapCallback(std_srvs::SetBool::Request  &req,
   return true;
 }
 
-
 void HectorMappingRos::publishMap(MapPublisherContainer& mapPublisher, const hectorslam::GridMap& gridMap, ros::Time timestamp, MapLockerInterface* mapMutex)
 {
   nav_msgs::GetMap::Response& map_ (mapPublisher.map_);

--- a/hector_mapping/src/HectorMappingRos.cpp
+++ b/hector_mapping/src/HectorMappingRos.cpp
@@ -394,13 +394,16 @@ bool HectorMappingRos::pauseMapCallback(std_srvs::SetBool::Request  &req,
 {
   if (req.data && !pause_scan_processing_)
   {
-    ROS_INFO("HectorSM Mapping paused");
+    res.message = "HectorSM Mapping paused";
+    ROS_INFO("%s", res.message.c_str());
   }
   else if (!req.data && pause_scan_processing_)
   {
-    ROS_INFO("HectorSM Mapping no longer paused");
+    res.message = "HectorSM Mapping no longer paused";
+    ROS_INFO("%s", res.message.c_str());
   }
   pause_scan_processing_ = req.data;
+  res.success = true;
   return true;
 }
 

--- a/hector_mapping/src/HectorMappingRos.cpp
+++ b/hector_mapping/src/HectorMappingRos.cpp
@@ -158,8 +158,8 @@ HectorMappingRos::HectorMappingRos()
     }
 
     // Initialize services to reset map, and toggle scan pause
-    resetMapService_ = node_.advertiseService("reset_map", &HectorMappingRos::resetMapCallback, this);
-    toggleScanProcessingService_ = node_.advertiseService("pause_mapping", &HectorMappingRos::pauseMapCallback, this);
+    reset_map_service_ = node_.advertiseService("reset_map", &HectorMappingRos::resetMapCallback, this);
+    toggle_scan_processing_service_ = node_.advertiseService("pause_mapping", &HectorMappingRos::pauseMapCallback, this);
 
     setServiceGetMapData(tmp.map_, slamProcessor->getGridMap(i));
 

--- a/hector_mapping/src/HectorMappingRos.h
+++ b/hector_mapping/src/HectorMappingRos.h
@@ -39,6 +39,9 @@
 #include "sensor_msgs/LaserScan.h"
 #include <std_msgs/String.h>
 
+#include <std_srvs/SetBool.h>
+#include <std_srvs/Trigger.h>
+
 #include "laser_geometry/laser_geometry.h"
 #include "nav_msgs/GetMap.h"
 
@@ -75,6 +78,8 @@ public:
   void sysMsgCallback(const std_msgs::String& string);
 
   bool mapCallback(nav_msgs::GetMap::Request  &req, nav_msgs::GetMap::Response &res);
+  bool resetMapCallback(std_srvs::Trigger::Request  &req, std_srvs::Trigger::Response &res);
+  bool pauseMapCallback(std_srvs::SetBool::Request  &req, std_srvs::SetBool::Response &res);
 
   void publishMap(MapPublisherContainer& map_, const hectorslam::GridMap& gridMap, ros::Time timestamp, MapLockerInterface* mapMutex = 0);
 
@@ -115,6 +120,9 @@ protected:
   ros::Publisher odometryPublisher_;
   ros::Publisher scan_point_cloud_publisher_;
 
+  ros::ServiceServer resetMapService_;
+  ros::ServiceServer toggleScanProcessingService_;
+
   std::vector<MapPublisherContainer> mapPubContainer;
 
   tf::TransformListener tf_;
@@ -140,6 +148,7 @@ protected:
   bool initial_pose_set_;
   Eigen::Vector3f initial_pose_;
 
+  bool pause_scan_processing_;
 
   //-----------------------------------------------------------
   // Parameters
@@ -182,7 +191,6 @@ protected:
   bool p_use_tf_pose_start_estimate_;
   bool p_map_with_known_poses_;
   bool p_timing_output_;
-
 
   float p_sqr_laser_min_dist_;
   float p_sqr_laser_max_dist_;

--- a/hector_mapping/src/HectorMappingRos.h
+++ b/hector_mapping/src/HectorMappingRos.h
@@ -120,8 +120,8 @@ protected:
   ros::Publisher odometryPublisher_;
   ros::Publisher scan_point_cloud_publisher_;
 
-  ros::ServiceServer resetMapService_;
-  ros::ServiceServer toggleScanProcessingService_;
+  ros::ServiceServer reset_map_service_;
+  ros::ServiceServer toggle_scan_processing_service_;
 
   std::vector<MapPublisherContainer> mapPubContainer;
 


### PR DESCRIPTION
I have an application in which I need to pause/resume/reset `hector_mapping`. I made these modifications, and I believe that it might be useful to other users as well.

I noticed that it was possible to reset the map by publishing the string `reset` in the topic `sys_msg_topic`, but I needed it to be a service call instead of a topic publishing (I needed to block my code execution until the map was effectively reset).

I hope that these modifications are considered useful, and that this can merge to the main branch.

Note: I will add comments to my code changes to clarify everything I did
Note 2: This PR would provide a solution to the old issue in https://github.com/tu-darmstadt-ros-pkg/hector_slam/issues/37
Note 3: This PR is backward-compatible, as it doesn't change any behavior for code that interfaces with `hector_mapping`, it only adds new services that can be used when interfacing with it

closes https://github.com/tu-darmstadt-ros-pkg/hector_slam/issues/37