### PR TITLE
Reorganize scanCallback and add comments

### DIFF
--- a/hector_mapping/include/hector_slam_lib/util/UtilFunctions.h
+++ b/hector_mapping/include/hector_slam_lib/util/UtilFunctions.h
@@ -31,7 +31,28 @@
 
 #include <cmath>
 
+#include <tf/transform_datatypes.h>
+#include <tf2_ros/transform_listener.h>
+
 namespace util{
+
+static inline bool LookupTransform(const std::string &from_frame,
+                                   const std::string &to_frame,
+                                   tf::StampedTransform *tf_output) {
+  // Create tf listener
+  tf2_ros::Buffer tf_buffer;
+  tf2_ros::TransformListener tf_listener(tf_buffer);
+  try {
+    const geometry_msgs::TransformStamped transform =
+        tf_buffer.lookupTransform(from_frame, to_frame, ros::Time(0), ros::Duration(10.0));
+    tf::transformStampedMsgToTF(transform, *tf_output);
+  } catch (tf2::TransformException &ex) {
+      ROS_WARN("HectorSM Transform between frame \"%s\" and frame \"%s\" was not found: %s",
+               from_frame.c_str(), to_frame.c_str(), ex.what());
+      return false;
+  }
+  return true;
+}
 
 static inline float normalize_angle_pos(float angle)
 {

--- a/hector_mapping/include/hector_slam_lib/util/UtilFunctions.h
+++ b/hector_mapping/include/hector_slam_lib/util/UtilFunctions.h
@@ -31,28 +31,7 @@
 
 #include <cmath>
 
-#include <tf/transform_datatypes.h>
-#include <tf2_ros/transform_listener.h>
-
 namespace util{
-
-static inline bool LookupTransform(const std::string &from_frame,
-                                   const std::string &to_frame,
-                                   tf::StampedTransform *tf_output) {
-  // Create tf listener
-  tf2_ros::Buffer tf_buffer;
-  tf2_ros::TransformListener tf_listener(tf_buffer);
-  try {
-    const geometry_msgs::TransformStamped transform =
-        tf_buffer.lookupTransform(from_frame, to_frame, ros::Time(0), ros::Duration(10.0));
-    tf::transformStampedMsgToTF(transform, *tf_output);
-  } catch (tf2::TransformException &ex) {
-      ROS_WARN("HectorSM Transform between frame \"%s\" and frame \"%s\" was not found: %s",
-               from_frame.c_str(), to_frame.c_str(), ex.what());
-      return false;
-  }
-  return true;
-}
 
 static inline float normalize_angle_pos(float angle)
 {

--- a/hector_mapping/src/HectorMappingRos.cpp
+++ b/hector_mapping/src/HectorMappingRos.cpp
@@ -231,31 +231,41 @@ HectorMappingRos::~HectorMappingRos()
     delete map__publish_thread_;
 }
 
-void HectorMappingRos::scanCallback(const sensor_msgs::LaserScan& scan) {
-  if (pause_scan_processing_) {
+void HectorMappingRos::scanCallback(const sensor_msgs::LaserScan& scan)
+{
+  if (pause_scan_processing_)
+  {
     return;
   }
 
-  if (hectorDrawings) {
+  if (hectorDrawings)
+  {
     hectorDrawings->setTime(scan.header.stamp);
   }
 
   ros::WallTime start_time = ros::WallTime::now();
-  if (!p_use_tf_scan_transformation_) {
+  if (!p_use_tf_scan_transformation_)
+  {
     // If we are not using the tf tree to find the transform between the base frame and laser frame,
     // then just convert the laser scan to our data container and process the update based on our last
     // pose estimate
-    if (rosLaserScanToDataContainer(scan, laserScanContainer,slamProcessor->getScaleToMap())) {
+    if (rosLaserScanToDataContainer(scan, laserScanContainer,slamProcessor->getScaleToMap()))
+    {
       slamProcessor->update(laserScanContainer,slamProcessor->getLastScanMatchPose());
     }
-  } else {
+  }
+  else
+  {
     // If we are using the tf tree to find the transform between the base frame and laser frame,
     // let's get that transform
     const ros::Duration dur (0.5);
     tf::StampedTransform laserTransform;
-    if (tf_.waitForTransform(p_base_frame_,scan.header.frame_id, scan.header.stamp,dur)) {
+    if (tf_.waitForTransform(p_base_frame_,scan.header.frame_id, scan.header.stamp,dur))
+    {
       tf_.lookupTransform(p_base_frame_,scan.header.frame_id, scan.header.stamp, laserTransform);
-    } else {
+    }
+    else
+    {
       ROS_INFO("lookupTransform %s to %s timed out. Could not transform laser scan into base_frame.", p_base_frame_.c_str(), scan.header.frame_id.c_str());
       return;
     }
@@ -264,24 +274,30 @@ void HectorMappingRos::scanCallback(const sensor_msgs::LaserScan& scan) {
     projector_.projectLaser(scan, laser_point_cloud_, 30.0);
 
     // Publish the point cloud if there are any subscribers
-    if (scan_point_cloud_publisher_.getNumSubscribers() > 0) {
+    if (scan_point_cloud_publisher_.getNumSubscribers() > 0)
+    {
       scan_point_cloud_publisher_.publish(laser_point_cloud_);
     }
 
     // Return if we can't convert the point cloud to our data container
-    if(!rosPointCloudToDataContainer(laser_point_cloud_, laserTransform, laserScanContainer, slamProcessor->getScaleToMap())) {
+    if(!rosPointCloudToDataContainer(laser_point_cloud_, laserTransform, laserScanContainer, slamProcessor->getScaleToMap()))
+    {
       return;
     }
 
     // Now let's choose the initial pose estimate for our slam process update
     Eigen::Vector3f start_estimate(Eigen::Vector3f::Zero());
-    if (initial_pose_set_) {
+    if (initial_pose_set_)
+    {
       // User has requested a pose reset
       initial_pose_set_ = false;
       start_estimate = initial_pose_;
-    } else if (p_use_tf_pose_start_estimate_){
+    }
+    else if (p_use_tf_pose_start_estimate_)
+    {
       // Initial pose estimate comes from the tf tree
-      try {
+      try
+      {
         tf::StampedTransform stamped_pose;
 
         tf_.waitForTransform(p_map_frame_,p_base_frame_, scan.header.stamp, ros::Duration(0.5));
@@ -289,31 +305,40 @@ void HectorMappingRos::scanCallback(const sensor_msgs::LaserScan& scan) {
 
         const double yaw = tf::getYaw(stamped_pose.getRotation());
         start_estimate = Eigen::Vector3f(stamped_pose.getOrigin().getX(),stamped_pose.getOrigin().getY(), yaw);
-      } catch(tf::TransformException e) {
+      }
+      catch(tf::TransformException e)
+      {
         ROS_ERROR("Transform from %s to %s failed\n", p_map_frame_.c_str(), p_base_frame_.c_str());
         start_estimate = slamProcessor->getLastScanMatchPose();
       }
-    } else {
+    }
+    else
+    {
       // If none of the above, the initial pose is simply the last estimated pose
       start_estimate = slamProcessor->getLastScanMatchPose();
     }
 
     // If "p_map_with_known_poses_" is enabled, we assume that start_estimate is precise and doesn't need to be refined
-    if (p_map_with_known_poses_) {
+    if (p_map_with_known_poses_)
+    {
       slamProcessor->update(laserScanContainer, start_estimate, true);
-    } else {
+    }
+    else
+    {
       slamProcessor->update(laserScanContainer, start_estimate);
     }
   }
 
   // If the debug flag "p_timing_output_" is enabled, print how long this last iteration took
-  if (p_timing_output_) {
+  if (p_timing_output_)
+  {
     ros::WallDuration duration = ros::WallTime::now() - start_time;
     ROS_INFO("HectorSLAM Iter took: %f milliseconds", duration.toSec()*1000.0f );
   }
 
   // If we're just building a map with known poses, we're finished now. Code below this point publishes the localization results.
-  if (p_map_with_known_poses_) {
+  if (p_map_with_known_poses_)
+  {
     return;
   }
 
@@ -324,7 +349,8 @@ void HectorMappingRos::scanCallback(const sensor_msgs::LaserScan& scan) {
   posePublisher_.publish(poseInfoContainer_.getPoseStamped());
 
   // Publish odometry if enabled
-  if(p_pub_odometry_) {
+  if(p_pub_odometry_)
+  {
     nav_msgs::Odometry tmp;
     tmp.pose = poseInfoContainer_.getPoseWithCovarianceStamped().pose;
 
@@ -334,12 +360,16 @@ void HectorMappingRos::scanCallback(const sensor_msgs::LaserScan& scan) {
   }
 
   // Publish the map->odom transform if enabled
-  if (p_pub_map_odom_transform_) {
+  if (p_pub_map_odom_transform_)
+  {
     tf::StampedTransform odom_to_base;
-    try {
+    try
+    {
       tf_.waitForTransform(p_odom_frame_, p_base_frame_, scan.header.stamp, ros::Duration(0.5));
       tf_.lookupTransform(p_odom_frame_, p_base_frame_, scan.header.stamp, odom_to_base);
-    } catch(tf::TransformException e) {
+    }
+    catch(tf::TransformException e)
+    {
       ROS_ERROR("Transform failed during publishing of map_odom transform: %s",e.what());
       odom_to_base.setIdentity();
     }
@@ -348,7 +378,8 @@ void HectorMappingRos::scanCallback(const sensor_msgs::LaserScan& scan) {
   }
 
   // Publish the transform from map to estimated pose (if enabled)
-  if (p_pub_map_scanmatch_transform_) {
+  if (p_pub_map_scanmatch_transform_)
+  {
     tfB_->sendTransform( tf::StampedTransform(poseInfoContainer_.getTfTransform(), scan.header.stamp, p_map_frame_, p_tf_map_scanmatch_transform_frame_name_));
   }
 }

--- a/hector_mapping/src/HectorMappingRos.cpp
+++ b/hector_mapping/src/HectorMappingRos.cpp
@@ -249,10 +249,8 @@ void HectorMappingRos::scanCallback(const sensor_msgs::LaserScan& scan)
     // If we are not using the tf tree to find the transform between the base frame and laser frame,
     // then just convert the laser scan to our data container and process the update based on our last
     // pose estimate
-    if (rosLaserScanToDataContainer(scan, laserScanContainer,slamProcessor->getScaleToMap()))
-    {
-      slamProcessor->update(laserScanContainer,slamProcessor->getLastScanMatchPose());
-    }
+    this->rosLaserScanToDataContainer(scan, laserScanContainer, slamProcessor->getScaleToMap());
+    slamProcessor->update(laserScanContainer, slamProcessor->getLastScanMatchPose());
   }
   else
   {
@@ -297,11 +295,11 @@ void HectorMappingRos::scanCallback(const sensor_msgs::LaserScan& scan)
       {
         tf::StampedTransform stamped_pose;
 
-        tf_.waitForTransform(p_map_frame_,p_base_frame_, scan.header.stamp, ros::Duration(0.5));
+        tf_.waitForTransform(p_map_frame_, p_base_frame_, scan.header.stamp, ros::Duration(0.5));
         tf_.lookupTransform(p_map_frame_, p_base_frame_,  scan.header.stamp, stamped_pose);
 
         const double yaw = tf::getYaw(stamped_pose.getRotation());
-        start_estimate = Eigen::Vector3f(stamped_pose.getOrigin().getX(),stamped_pose.getOrigin().getY(), yaw);
+        start_estimate = Eigen::Vector3f(stamped_pose.getOrigin().getX(), stamped_pose.getOrigin().getY(), yaw);
       }
       catch(tf::TransformException e)
       {
@@ -472,7 +470,7 @@ void HectorMappingRos::publishMap(MapPublisherContainer& mapPublisher, const hec
   mapPublisher.mapPublisher_.publish(map_.map);
 }
 
-bool HectorMappingRos::rosLaserScanToDataContainer(const sensor_msgs::LaserScan& scan, hectorslam::DataContainer& dataContainer, float scaleToMap)
+void HectorMappingRos::rosLaserScanToDataContainer(const sensor_msgs::LaserScan& scan, hectorslam::DataContainer& dataContainer, float scaleToMap)
 {
   size_t size = scan.ranges.size();
 
@@ -496,8 +494,6 @@ bool HectorMappingRos::rosLaserScanToDataContainer(const sensor_msgs::LaserScan&
 
     angle += scan.angle_increment;
   }
-
-  return true;
 }
 
 void HectorMappingRos::rosPointCloudToDataContainer(const sensor_msgs::PointCloud& pointCloud, const tf::StampedTransform& laserTransform, hectorslam::DataContainer& dataContainer, float scaleToMap)

--- a/hector_mapping/src/HectorMappingRos.cpp
+++ b/hector_mapping/src/HectorMappingRos.cpp
@@ -259,10 +259,10 @@ void HectorMappingRos::scanCallback(const sensor_msgs::LaserScan& scan)
     // If we are using the tf tree to find the transform between the base frame and laser frame,
     // let's get that transform
     const ros::Duration dur(0.5);
-    tf::StampedTransform laserTransform;
+    tf::StampedTransform laser_transform;
     if (tf_.waitForTransform(p_base_frame_, scan.header.frame_id, scan.header.stamp, dur))
     {
-      tf_.lookupTransform(p_base_frame_, scan.header.frame_id, scan.header.stamp, laserTransform);
+      tf_.lookupTransform(p_base_frame_, scan.header.frame_id, scan.header.stamp, laser_transform);
     }
     else
     {
@@ -280,7 +280,7 @@ void HectorMappingRos::scanCallback(const sensor_msgs::LaserScan& scan)
     }
 
     // Convert the point cloud to our data container
-    this->rosPointCloudToDataContainer(laser_point_cloud_, laserTransform, laserScanContainer, slamProcessor->getScaleToMap());
+    this->rosPointCloudToDataContainer(laser_point_cloud_, laser_transform, laserScanContainer, slamProcessor->getScaleToMap());
 
     // Now let's choose the initial pose estimate for our slam process update
     Eigen::Vector3f start_estimate(Eigen::Vector3f::Zero());

--- a/hector_mapping/src/HectorMappingRos.cpp
+++ b/hector_mapping/src/HectorMappingRos.cpp
@@ -258,11 +258,11 @@ void HectorMappingRos::scanCallback(const sensor_msgs::LaserScan& scan)
   {
     // If we are using the tf tree to find the transform between the base frame and laser frame,
     // let's get that transform
-    const ros::Duration dur (0.5);
+    const ros::Duration dur(0.5);
     tf::StampedTransform laserTransform;
-    if (tf_.waitForTransform(p_base_frame_,scan.header.frame_id, scan.header.stamp,dur))
+    if (tf_.waitForTransform(p_base_frame_, scan.header.frame_id, scan.header.stamp, dur))
     {
-      tf_.lookupTransform(p_base_frame_,scan.header.frame_id, scan.header.stamp, laserTransform);
+      tf_.lookupTransform(p_base_frame_, scan.header.frame_id, scan.header.stamp, laserTransform);
     }
     else
     {

--- a/hector_mapping/src/HectorMappingRos.cpp
+++ b/hector_mapping/src/HectorMappingRos.cpp
@@ -264,7 +264,7 @@ void HectorMappingRos::scanCallback(const sensor_msgs::LaserScan& scan) {
     projector_.projectLaser(scan, laser_point_cloud_, 30.0);
 
     // Publish the point cloud if there are any subscribers
-    if (scan_point_cloud_publisher_.getNumSubscribers() > 0){
+    if (scan_point_cloud_publisher_.getNumSubscribers() > 0) {
       scan_point_cloud_publisher_.publish(laser_point_cloud_);
     }
 

--- a/hector_mapping/src/HectorMappingRos.cpp
+++ b/hector_mapping/src/HectorMappingRos.cpp
@@ -279,11 +279,8 @@ void HectorMappingRos::scanCallback(const sensor_msgs::LaserScan& scan)
       scan_point_cloud_publisher_.publish(laser_point_cloud_);
     }
 
-    // Return if we can't convert the point cloud to our data container
-    if(!rosPointCloudToDataContainer(laser_point_cloud_, laserTransform, laserScanContainer, slamProcessor->getScaleToMap()))
-    {
-      return;
-    }
+    // Convert the point cloud to our data container
+    this->rosPointCloudToDataContainer(laser_point_cloud_, laserTransform, laserScanContainer, slamProcessor->getScaleToMap());
 
     // Now let's choose the initial pose estimate for our slam process update
     Eigen::Vector3f start_estimate(Eigen::Vector3f::Zero());
@@ -503,7 +500,7 @@ bool HectorMappingRos::rosLaserScanToDataContainer(const sensor_msgs::LaserScan&
   return true;
 }
 
-bool HectorMappingRos::rosPointCloudToDataContainer(const sensor_msgs::PointCloud& pointCloud, const tf::StampedTransform& laserTransform, hectorslam::DataContainer& dataContainer, float scaleToMap)
+void HectorMappingRos::rosPointCloudToDataContainer(const sensor_msgs::PointCloud& pointCloud, const tf::StampedTransform& laserTransform, hectorslam::DataContainer& dataContainer, float scaleToMap)
 {
   size_t size = pointCloud.points.size();
   //ROS_INFO("size: %d", size);
@@ -536,8 +533,6 @@ bool HectorMappingRos::rosPointCloudToDataContainer(const sensor_msgs::PointClou
       }
     }
   }
-
-  return true;
 }
 
 void HectorMappingRos::setServiceGetMapData(nav_msgs::GetMap::Response& map_, const hectorslam::GridMap& gridMap)

--- a/hector_mapping/src/HectorMappingRos.cpp
+++ b/hector_mapping/src/HectorMappingRos.cpp
@@ -240,8 +240,7 @@ void HectorMappingRos::scanCallback(const sensor_msgs::LaserScan& scan) {
     hectorDrawings->setTime(scan.header.stamp);
   }
 
-  ros::WallTime startTime = ros::WallTime::now();
-
+  ros::WallTime start_time = ros::WallTime::now();
   if (!p_use_tf_scan_transformation_) {
     // If we are not using the tf tree to find the transform between the base frame and laser frame,
     // then just convert the laser scan to our data container and process the update based on our last
@@ -275,11 +274,11 @@ void HectorMappingRos::scanCallback(const sensor_msgs::LaserScan& scan) {
     }
 
     // Now let's choose the initial pose estimate for our slam process update
-    Eigen::Vector3f startEstimate(Eigen::Vector3f::Zero());
+    Eigen::Vector3f start_estimate(Eigen::Vector3f::Zero());
     if (initial_pose_set_) {
       // User has requested a pose reset
       initial_pose_set_ = false;
-      startEstimate = initial_pose_;
+      start_estimate = initial_pose_;
     } else if (p_use_tf_pose_start_estimate_){
       // Initial pose estimate comes from the tf tree
       try {
@@ -289,27 +288,27 @@ void HectorMappingRos::scanCallback(const sensor_msgs::LaserScan& scan) {
         tf_.lookupTransform(p_map_frame_, p_base_frame_,  scan.header.stamp, stamped_pose);
 
         const double yaw = tf::getYaw(stamped_pose.getRotation());
-        startEstimate = Eigen::Vector3f(stamped_pose.getOrigin().getX(),stamped_pose.getOrigin().getY(), yaw);
+        start_estimate = Eigen::Vector3f(stamped_pose.getOrigin().getX(),stamped_pose.getOrigin().getY(), yaw);
       } catch(tf::TransformException e) {
         ROS_ERROR("Transform from %s to %s failed\n", p_map_frame_.c_str(), p_base_frame_.c_str());
-        startEstimate = slamProcessor->getLastScanMatchPose();
+        start_estimate = slamProcessor->getLastScanMatchPose();
       }
     } else {
       // If none of the above, the initial pose is simply the last estimated pose
-      startEstimate = slamProcessor->getLastScanMatchPose();
+      start_estimate = slamProcessor->getLastScanMatchPose();
     }
 
-    // If "p_map_with_known_poses_" is enabled, we assume that startEstimate is precise and doesn't need to be refined
+    // If "p_map_with_known_poses_" is enabled, we assume that start_estimate is precise and doesn't need to be refined
     if (p_map_with_known_poses_) {
-      slamProcessor->update(laserScanContainer, startEstimate, true);
+      slamProcessor->update(laserScanContainer, start_estimate, true);
     } else {
-      slamProcessor->update(laserScanContainer, startEstimate);
+      slamProcessor->update(laserScanContainer, start_estimate);
     }
   }
 
   // If the debug flag "p_timing_output_" is enabled, print how long this last iteration took
   if (p_timing_output_) {
-    ros::WallDuration duration = ros::WallTime::now() - startTime;
+    ros::WallDuration duration = ros::WallTime::now() - start_time;
     ROS_INFO("HectorSLAM Iter took: %f milliseconds", duration.toSec()*1000.0f );
   }
 

--- a/hector_mapping/src/HectorMappingRos.h
+++ b/hector_mapping/src/HectorMappingRos.h
@@ -84,7 +84,7 @@ public:
   void publishMap(MapPublisherContainer& map_, const hectorslam::GridMap& gridMap, ros::Time timestamp, MapLockerInterface* mapMutex = 0);
 
   bool rosLaserScanToDataContainer(const sensor_msgs::LaserScan& scan, hectorslam::DataContainer& dataContainer, float scaleToMap);
-  bool rosPointCloudToDataContainer(const sensor_msgs::PointCloud& pointCloud, const tf::StampedTransform& laserTransform, hectorslam::DataContainer& dataContainer, float scaleToMap);
+  void rosPointCloudToDataContainer(const sensor_msgs::PointCloud& pointCloud, const tf::StampedTransform& laserTransform, hectorslam::DataContainer& dataContainer, float scaleToMap);
 
   void setServiceGetMapData(nav_msgs::GetMap::Response& map_, const hectorslam::GridMap& gridMap);
 

--- a/hector_mapping/src/HectorMappingRos.h
+++ b/hector_mapping/src/HectorMappingRos.h
@@ -83,7 +83,7 @@ public:
 
   void publishMap(MapPublisherContainer& map_, const hectorslam::GridMap& gridMap, ros::Time timestamp, MapLockerInterface* mapMutex = 0);
 
-  bool rosLaserScanToDataContainer(const sensor_msgs::LaserScan& scan, hectorslam::DataContainer& dataContainer, float scaleToMap);
+  void rosLaserScanToDataContainer(const sensor_msgs::LaserScan& scan, hectorslam::DataContainer& dataContainer, float scaleToMap);
   void rosPointCloudToDataContainer(const sensor_msgs::PointCloud& pointCloud, const tf::StampedTransform& laserTransform, hectorslam::DataContainer& dataContainer, float scaleToMap);
 
   void setServiceGetMapData(nav_msgs::GetMap::Response& map_, const hectorslam::GridMap& gridMap);


### PR DESCRIPTION
This PR has no functional changes, it only reorganizes the `scanCallback` function while adding comments. I really hope that the changes in here will be appreciated as a natural code hygiene. I am totally open for suggestions, criticism, comments to make this better!

Most importantly, the `scanCallback` has a lot of nested if/else statements, and I un-nested some of them for readability.

Here are the main changes done in this PR:
- Un-nesting some if/else statements for better readability
- Adding comments to some chunks of code
- Made some variables `snake_case`
- Usage of [google's c++ style guide](https://google.github.io/styleguide/cppguide.html) for curly bracket usage:
-- The open curly brace is always on the end of the last line of the function declaration, not the start of the next line.
-- The close curly brace is either on the last line by itself or on the same line as the open curly brace.
-- There should be a space between the close parenthesis and the open curly brace.