### PR TITLE
Cache static tf transforms from base to lidar frames at node startup

### DIFF
--- a/hector_mapping/CMakeLists.txt
+++ b/hector_mapping/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.0.2)
 project(hector_mapping)
 
+add_compile_options(-std=c++11)
+
 find_package(catkin REQUIRED COMPONENTS 
   roscpp
   nav_msgs

--- a/hector_mapping/include/hector_slam_lib/util/UtilFunctions.h
+++ b/hector_mapping/include/hector_slam_lib/util/UtilFunctions.h
@@ -31,7 +31,29 @@
 
 #include <cmath>
 
-namespace util{
+#include <tf/transform_datatypes.h>
+#include <tf2_ros/transform_listener.h>
+
+namespace util
+{
+
+static inline bool LookupTransform(const std::string &from_frame,
+                                   const std::string &to_frame,
+                                   tf::StampedTransform *tf_output) {
+  // Create tf listener
+  tf2_ros::Buffer tf_buffer;
+  tf2_ros::TransformListener tf_listener(tf_buffer);
+  try {
+    const geometry_msgs::TransformStamped transform =
+        tf_buffer.lookupTransform(from_frame, to_frame, ros::Time(0), ros::Duration(2.0));
+    tf::transformStampedMsgToTF(transform, *tf_output);
+  } catch (tf2::TransformException &ex) {
+      ROS_WARN("HectorSM Transform between frame \"%s\" and frame \"%s\" was not found: %s",
+               from_frame.c_str(), to_frame.c_str(), ex.what());
+      return false;
+  }
+  return true;
+}
 
 static inline float normalize_angle_pos(float angle)
 {

--- a/hector_mapping/launch/mapping_default.launch
+++ b/hector_mapping/launch/mapping_default.launch
@@ -43,7 +43,7 @@
     <param name="scan_topic" value="$(arg scan_topic)"/>
 
     <!-- Uncomment the following if there are any laser scanners that are static w.r.t. the robot's base_frame. If so, this node caches these static transforms at node startup, preventing repetitive tf tree lookups in unreliable networks -->
-    <rosparam param="static_laser_frame_ids"> ["laser_frame1", "laser_frame2"] </rosparam>
+    <!-- <rosparam param="static_laser_frame_ids"> ["example_laser_frame1", "example_laser_frame2"] </rosparam> -->
     
     <!-- Debug parameters -->
     <!--

--- a/hector_mapping/launch/mapping_default.launch
+++ b/hector_mapping/launch/mapping_default.launch
@@ -41,6 +41,9 @@
     
     <param name="scan_subscriber_queue_size" value="$(arg scan_subscriber_queue_size)"/>
     <param name="scan_topic" value="$(arg scan_topic)"/>
+
+    <!-- Uncomment the following if there are any laser scanners that are static w.r.t. the robot's base_frame. If so, this node caches these static transforms at node startup, preventing repetitive tf tree lookups in unreliable networks -->
+    <rosparam param="static_laser_frame_ids"> ["laser_frame1", "laser_frame2"] </rosparam>
     
     <!-- Debug parameters -->
     <!--

--- a/hector_mapping/src/HectorMappingRos.h
+++ b/hector_mapping/src/HectorMappingRos.h
@@ -51,6 +51,7 @@
 #include "util/MapLockerInterface.h"
 
 #include <boost/thread.hpp>
+#include <unordered_map>
 
 #include "PoseInfoContainer.h"
 
@@ -149,6 +150,9 @@ protected:
   Eigen::Vector3f initial_pose_;
 
   bool pause_scan_processing_;
+
+  // Hash table to cache static transforms from base_frame to lidar frames
+  std::unordered_map<std::string, tf::StampedTransform> cached_static_lidar_transforms_;
 
   //-----------------------------------------------------------
   // Parameters


### PR DESCRIPTION
Motivation: see https://github.com/tu-darmstadt-ros-pkg/hector_slam/issues/90
closes #90 

Design constraints:
- Backwards compatibility: this change does not affect those who uses hector without caching static transforms at node startup
- Allow multiple transforms from `base_frame` to `laser_frame_ids` to be cached: the proposed solution does not assume that there is only one laser scanner on the robot
- The node will still lookup for the transforms of non-static lidar frames (e.g., a manipulator with a laser scanner) or non-cached static lidar frames

Design decisions:
- The implemented solution requires c++11 and above. Since the branch's name is `noetic-devel`, and `Noetic` assumes c++14 as a target compiler, I didn't think that this would impose a constraint on anyone using this branch.