### PR TITLE
Remove tf_conversions as a dependency

### DIFF
--- a/hector_mapping/CMakeLists.txt
+++ b/hector_mapping/CMakeLists.txt
@@ -8,7 +8,6 @@ find_package(catkin REQUIRED COMPONENTS
   tf
   message_filters
   laser_geometry
-  tf_conversions
   message_generation
   std_srvs)
 
@@ -44,7 +43,7 @@ generate_messages(
 catkin_package(
   INCLUDE_DIRS include
 #  LIBRARIES hector_mapping
-  CATKIN_DEPENDS roscpp nav_msgs visualization_msgs tf message_filters laser_geometry tf_conversions message_runtime
+  CATKIN_DEPENDS roscpp nav_msgs visualization_msgs tf message_filters laser_geometry message_runtime
   DEPENDS EIGEN3
 )
 

--- a/hector_mapping/package.xml
+++ b/hector_mapping/package.xml
@@ -47,7 +47,6 @@
   <build_depend>tf</build_depend>
   <build_depend>message_filters</build_depend>
   <build_depend>laser_geometry</build_depend>
-  <build_depend>tf_conversions</build_depend>
   <build_depend>eigen</build_depend>
   <build_depend>boost</build_depend>
   <build_depend>message_generation</build_depend>
@@ -57,7 +56,6 @@
   <run_depend>tf</run_depend>
   <run_depend>message_filters</run_depend>
   <run_depend>laser_geometry</run_depend>
-  <run_depend>tf_conversions</run_depend>
   <run_depend>eigen</run_depend>
   <run_depend>boost</run_depend>
   <run_depend>message_runtime</run_depend>


### PR DESCRIPTION
This isn't a super important PR, but I realized that we could delete `tf_conversions` from the list of dependencies, as it isn't used by `hector_mapping` any longer