### PR TITLE
use boost::placeholders::_1 instead of deprecated _1

### DIFF
--- a/hector_geotiff/CMakeLists.txt
+++ b/hector_geotiff/CMakeLists.txt
@@ -1,6 +1,5 @@
 cmake_minimum_required(VERSION 3.0.2)
 project(hector_geotiff)
-set(CMAKE_CXX_STANDARD 14)
 
 find_package(catkin REQUIRED COMPONENTS hector_map_tools hector_nav_msgs nav_msgs pluginlib roscpp std_msgs)
 

--- a/hector_geotiff/src/geotiff_node.cpp
+++ b/hector_geotiff/src/geotiff_node.cpp
@@ -33,7 +33,7 @@
 #include <ros/ros.h>
 #include <ros/console.h>
 
-#include <pluginlib/class_loader.h>
+#include <pluginlib/class_loader.hpp>
 
 #include <memory>
 #include <boost/algorithm/string.hpp>

--- a/hector_geotiff_plugins/src/trajectory_geotiff_plugin.cpp
+++ b/hector_geotiff_plugins/src/trajectory_geotiff_plugin.cpp
@@ -119,5 +119,5 @@ void TrajectoryMapWriter::draw(MapWriterInterface *interface)
 } // namespace
 
 //register this planner as a MapWriterPluginInterface plugin
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 PLUGINLIB_EXPORT_CLASS(hector_geotiff_plugins::TrajectoryMapWriter, hector_geotiff::MapWriterPluginInterface)

--- a/hector_mapping/src/HectorMappingRos.cpp
+++ b/hector_mapping/src/HectorMappingRos.cpp
@@ -205,7 +205,7 @@ HectorMappingRos::HectorMappingRos()
 
   initial_pose_sub_ = new message_filters::Subscriber<geometry_msgs::PoseWithCovarianceStamped>(node_, "initialpose", 2);
   initial_pose_filter_ = new tf::MessageFilter<geometry_msgs::PoseWithCovarianceStamped>(*initial_pose_sub_, tf_, p_map_frame_, 2);
-  initial_pose_filter_->registerCallback(boost::bind(&HectorMappingRos::initialPoseCallback, this, _1));
+  initial_pose_filter_->registerCallback(boost::bind(&HectorMappingRos::initialPoseCallback, this, boost::placeholders::_1));
 
 
   map__publish_thread_ = new boost::thread(boost::bind(&HectorMappingRos::publishMapLoop, this, p_map_pub_period_));


### PR DESCRIPTION
Also use default…C++, which will be 14 in noetic, 17 on newer systems which will resolve log4cxx 0.12 error:

```
Errors     << hector_geotiff:make /home/lucasw/base_catkin_ws/logs/hector_geotiff/build.make.003.log                                                                                                                          
In file included from /usr/include/log4cxx/log4cxx.h:45,
                 from /usr/include/log4cxx/logstring.h:28,
                 from /usr/include/log4cxx/level.h:22,
                 from /usr/include/ros/console.h:46,
                 from /home/lucasw/base_catkin_ws/src/other/hector_slam/hector_geotiff/src/geotiff_writer/geotiff_writer.cpp:30:
/usr/include/log4cxx/boost-std-configuration.h:10:18: error: ‘shared_mutex’ in namespace ‘std’ does not name a type
   10 |     typedef std::shared_mutex shared_mutex;
      |                  ^~~~~~~~~~~~
/usr/include/log4cxx/boost-std-configuration.h:10:13: note: ‘std::shared_mutex’ is only available from C++17 onwards
   10 |     typedef std::shared_mutex shared_mutex;
      |             ^~~

```