### PR TITLE
Enforce C++ 17 on geotiff for ROS-One

### DIFF
--- a/hector_geotiff/CMakeLists.txt
+++ b/hector_geotiff/CMakeLists.txt
@@ -1,6 +1,5 @@
 cmake_minimum_required(VERSION 3.0.2)
 project(hector_geotiff)
-set(CMAKE_CXX_STANDARD 17)
 
 find_package(catkin REQUIRED COMPONENTS hector_map_tools hector_nav_msgs nav_msgs pluginlib roscpp std_msgs)
 

--- a/hector_geotiff/CMakeLists.txt
+++ b/hector_geotiff/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.0.2)
 project(hector_geotiff)
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 
 find_package(catkin REQUIRED COMPONENTS hector_map_tools hector_nav_msgs nav_msgs pluginlib roscpp std_msgs)
 


### PR DESCRIPTION
This PR fixes compilation issues on Ubuntu Jammy for the [ros-o project](https://ros.packages.techfak.net/) and is linked with https://github.com/ubi-agni/ros-builder-action/pull/67

The only change involves setting C++17 instead of 14 on the `hector_geotiff` package.

I'm creating this PR against the `noetic-devel` but if you think it is incompatible with `noetic`, feel free to incorporate it into a new upstream branch called `ros-o-devel` which will then be tracked by `ros-o`.

Best regards,
Marco. 